### PR TITLE
fixes cpan #103765

### DIFF
--- a/HiRes.pm
+++ b/HiRes.pm
@@ -510,7 +510,7 @@ modglobal hash:
 
   name             C prototype
   ---------------  ----------------------
-  Time::NVtime     double (*)()
+  Time::NVtime     NV (*)()
   Time::U2time     void (*)(pTHX_ UV ret[2])
 
 Both functions return equivalent information (like C<gettimeofday>)
@@ -521,12 +521,12 @@ VMS have emulations for it.)
 
 Here is an example of using C<NVtime> from C:
 
-  double (*myNVtime)(); /* Returns -1 on failure. */
+  NV (*myNVtime)(); /* Returns -1 on failure. */
   SV **svp = hv_fetch(PL_modglobal, "Time::NVtime", 12, 0);
   if (!svp)         croak("Time::HiRes is required");
   if (!SvIOK(*svp)) croak("Time::NVtime isn't a function pointer");
-  myNVtime = INT2PTR(double(*)(), SvIV(*svp));
-  printf("The current time is: %f\n", (*myNVtime)());
+  myNVtime = INT2PTR(NV(*)(), SvIV(*svp));
+  printf("The current time is: %" NVff "\n", (*myNVtime)());
 
 =head1 DIAGNOSTICS
 


### PR DESCRIPTION
Time::HiRes has always used NV as the return value of the function
pointer stored in Time::NVtime, which is fine when perl is built
with default settings, since NV is then just double.

However, if perl is built with -Duselongdouble, NV becomes long double,
and code that follows the documentation exhibits hard to debug
behaviour, eg. [perl #123879].

Some modules on CPAN that use this interface follow the documentation
and some follow the implementation, changing the implementation would
break modules that follow the implementation and break backward
compatibility, so update the documentation.